### PR TITLE
Notify property change in a more robust way

### DIFF
--- a/src/Qml.Net.Chat.Client/Controllers/ChatController.cs
+++ b/src/Qml.Net.Chat.Client/Controllers/ChatController.cs
@@ -72,7 +72,9 @@ namespace Chat.Client.Controllers
         private void AddChatMessage(ChatMessage chatMessage)
         {
             ChatMessages.Add(chatMessage);
-            this.ActivateSignal("chatMessagesChanged");
+            this.ActivateNotifySignal(nameof(ChatMessages));
+            // or
+            // this.ActivateProperty(o => o.ChatMessages);
         }
     }
 }


### PR DESCRIPTION
I found out that there are 4 ways to notify signals, 3 of which are well suited for notifying property changes:

		[NotifySignal]
		public string AppName
		{
			get => _appName;
			set
			{
				//_appName = value;
				//this.ActivateSignal("appNameChanged");

				_appName = value;
				this.ActivateNotifySignal();
				//this.ActivateNotifySignal(nameof(AppName));

				//_appName = value;
				//this.ActivateProperty(appModel => appModel.AppName);

				//this.SetProperty(ref _appName, value);
			}
		}


I believe this.ActivateSignal is best suited to trigger custom signals defined on the class.